### PR TITLE
Update routerID metric to expose router-id value

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ make qtest
 | **Metric** | **Description** | **Labels** |
 | ------ | ------- | ------ |
 | `gobgp_router_up` | Is GoBGP up and responds to queries (1) or is it down (0). | |
-| `gobgp_router_id` | What is GoBGP router ID. | |
+| `gobgp_router_id` | What is GoBGP router ID. | `id` |
 | `gobgp_router_asn` | What is GoBGP AS number. | |
 | `gobgp_router_failed_req_count` | The number of failed requests to GoBGP router. | |
 | `gobgp_router_next_poll` | The timestamp of the next potential scrape of the router. | |

--- a/pkg/gobgp_exporter/collect.go
+++ b/pkg/gobgp_exporter/collect.go
@@ -99,6 +99,7 @@ func (n *RouterNode) GatherMetrics() {
 			routerID,
 			prometheus.GaugeValue,
 			1,
+			n.routerID,
 		))
 	}
 	if n.localAS > 0 {

--- a/pkg/gobgp_exporter/describe_node.go
+++ b/pkg/gobgp_exporter/describe_node.go
@@ -27,7 +27,7 @@ var (
 	routerID = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "router", "id"),
 		"What is GoBGP router ID.",
-		nil, nil,
+		[]string{"id"}, nil,
 	)
 	routerLocalAS = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "router", "asn"),


### PR DESCRIPTION
### Summary
routerID metric was always 1.
this was missing the routerID value, 
which i find it useful, since i am running
more than a instance of gobgp-daemon.

with this update, the routerID value is exposed
as a label, which can than be scraped by prom
and makes it available, so we can have a richer
dashboard with the relevant datapoints