### PR TITLE
Adding description label to peer-specific metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,33 +31,33 @@ make qtest
 | `gobgp_route_total_path_count` | The number of available paths to destinations on per address family and route table basis | `address_family`, `route_table`, `vrf_name` |
 | `gobgp_route_accepted_path_count` | The number of accepted paths to destinations on per address family and route table basis | `address_family`, `route_table`, `vrf_name` |
 | `gobgp_peer_count` | The number of BGP peers | |
-| `gobgp_peer_up` | Is the peer up and in established state (1) or it is not (0). | `name` |
-| `gobgp_peer_asn` | What is the AS number of the peer | `name` |
-| `gobgp_peer_local_asn` | What is the AS number presented to the peer by this router. | `name` |
-| `gobgp_peer_admin_state` | Is the peer configured for being Up (0), Down (1), or PFX_CT (2) | `name` |
-| `gobgp_peer_session_state` | What is the state of BGP session to the peer - unknown (0), idle (1), connect (2), active (3), opensent (4), openconfirm (5), established (6) | `name` |
-| `gobgp_peer_received_message_total_count` | The total number of messages the BGP peer sent to this router (limited to IPv4). | `name` |
-| `gobgp_peer_received_notification_message_count` | How many Notification messages did the BGP peer sent to this router (limited to IPv4). | `name` |
-| `gobgp_peer_received_update_message_count` | How many Update messages did the BGP peer sent to this router (limited to IPv4). | `name` |
-| `gobgp_peer_received_open_message_count` | How many Open messages did the BGP peer sent to this router (limited to IPv4). | `name` |
-| `gobgp_peer_received_keepalive_message_count` | How many messages did the BGP peer sent to this router (limited to IPv4). | `name` |
-| `gobgp_peer_received_refresh_message_count` | How many Refresh messages did the BGP peer sent to this router (limited to IPv4). | `name` |
-| `gobgp_peer_received_withdraw_update_message_count` | How many WithdrawUpdate messages did the BGP peer sent to this router (limited to IPv4). | `name` |
-| `gobgp_peer_received_withdraw_prefix_message_count` | How many messages did the BGP peer sent to this router (limited to IPv4). | `name` |
-| `gobgp_peer_sent_message_total_count` | The total number of messages this router sent to this BGP peer (limited to IPv4). | `name` |
-| `gobgp_peer_sent_notification_message_count` | How many Notification messages did this router sent to this BGP peer (limited to IPv4). | `name` |
-| `gobgp_peer_sent_update_message_count` | How many Update messages did this router sent to this BGP peer (limited to IPv4). | `name` |
-| `gobgp_peer_sent_open_message_count` | How many Open messages did this router sent to this BGP peer (limited to IPv4). | `name` |
-| `gobgp_peer_sent_keepalive_message_count` | How many messages did this router sent to this BGP peer (limited to IPv4). | `name` |
-| `gobgp_peer_sent_refresh_message_count` | How many Refresh messages did this router sent to this BGP peer (limited to IPv4). | `name` |
-| `gobgp_peer_sent_withdraw_update_message_count` | How many WithdrawUpdate messages did this router sent to this BGP peer (limited to IPv4). | `name` |
-| `gobgp_peer_sent_withdraw_prefix_message_count` | How many messages did this router sent to this BGP peer (limited to IPv4). | `name` |
-| `gobgp_peer_out_queue_count` | PeerState.OutQ | `name` |
-| `gobgp_peer_flop_count` | PeerState.Flops | `name` |
-| `gobgp_peer_send_community` | PeerState.SendCommunity | `name` |
-| `gobgp_peer_remove_private_as` | PeerState.RemovePrivateAs | `name` |
-| `gobgp_peer_password_set` | Whether the GoBGP peer has been configured (1) for authentication or not (0) | `name` |
-| `gobgp_peer_type` | PeerState.PeerType | `name` |
+| `gobgp_peer_up` | Is the peer up and in established state (1) or it is not (0). | `name`, `description` |
+| `gobgp_peer_asn` | What is the AS number of the peer | `name`, `description` |
+| `gobgp_peer_local_asn` | What is the AS number presented to the peer by this router. | `name`, `description` |
+| `gobgp_peer_admin_state` | Is the peer configured for being Up (0), Down (1), or PFX_CT (2) | `name`, `description` |
+| `gobgp_peer_session_state` | What is the state of BGP session to the peer - unknown (0), idle (1), connect (2), active (3), opensent (4), openconfirm (5), established (6) | `name`, `description` |
+| `gobgp_peer_received_message_total_count` | The total number of messages the BGP peer sent to this router (limited to IPv4). | `name`, `description` |
+| `gobgp_peer_received_notification_message_count` | How many Notification messages did the BGP peer sent to this router (limited to IPv4). | `name`, `description` |
+| `gobgp_peer_received_update_message_count` | How many Update messages did the BGP peer sent to this router (limited to IPv4). | `name`, `description` |
+| `gobgp_peer_received_open_message_count` | How many Open messages did the BGP peer sent to this router (limited to IPv4). | `name`, `description` |
+| `gobgp_peer_received_keepalive_message_count` | How many messages did the BGP peer sent to this router (limited to IPv4). | `name`, `description` |
+| `gobgp_peer_received_refresh_message_count` | How many Refresh messages did the BGP peer sent to this router (limited to IPv4). | `name`, `description` |
+| `gobgp_peer_received_withdraw_update_message_count` | How many WithdrawUpdate messages did the BGP peer sent to this router (limited to IPv4). | `name`, `description` |
+| `gobgp_peer_received_withdraw_prefix_message_count` | How many messages did the BGP peer sent to this router (limited to IPv4). | `name`, `description` |
+| `gobgp_peer_sent_message_total_count` | The total number of messages this router sent to this BGP peer (limited to IPv4). | `name`, `description` |
+| `gobgp_peer_sent_notification_message_count` | How many Notification messages did this router sent to this BGP peer (limited to IPv4). | `name`, `description` |
+| `gobgp_peer_sent_update_message_count` | How many Update messages did this router sent to this BGP peer (limited to IPv4). | `name`, `description` |
+| `gobgp_peer_sent_open_message_count` | How many Open messages did this router sent to this BGP peer (limited to IPv4). | `name`, `description` |
+| `gobgp_peer_sent_keepalive_message_count` | How many messages did this router sent to this BGP peer (limited to IPv4). | `name`, `description` |
+| `gobgp_peer_sent_refresh_message_count` | How many Refresh messages did this router sent to this BGP peer (limited to IPv4). | `name`, `description` |
+| `gobgp_peer_sent_withdraw_update_message_count` | How many WithdrawUpdate messages did this router sent to this BGP peer (limited to IPv4). | `name`, `description` |
+| `gobgp_peer_sent_withdraw_prefix_message_count` | How many messages did this router sent to this BGP peer (limited to IPv4). | `name`, `description` |
+| `gobgp_peer_out_queue_count` | PeerState.OutQ | `name`, `description` |
+| `gobgp_peer_flop_count` | PeerState.Flops | `name`, `description` |
+| `gobgp_peer_send_community` | PeerState.SendCommunity | `name`, `description` |
+| `gobgp_peer_remove_private_as` | PeerState.RemovePrivateAs | `name`, `description` |
+| `gobgp_peer_password_set` | Whether the GoBGP peer has been configured (1) for authentication or not (0) | `name`, `description` |
+| `gobgp_peer_type` | PeerState.PeerType | `name`, `description` |
 
 For example:
 

--- a/pkg/gobgp_exporter/collect_peers.go
+++ b/pkg/gobgp_exporter/collect_peers.go
@@ -60,6 +60,8 @@ func (n *RouterNode) GetPeers() {
 	for _, p := range peers {
 		peerState := p.GetState()
 		peerRouterID := peerState.GetNeighborAddress()
+		peerConf := p.GetConf()
+		peerDescription := peerConf.GetDescription()
 
 		// Peer Up/Down
 		if peerState.GetRouterId() != "" {
@@ -68,6 +70,7 @@ func (n *RouterNode) GetPeers() {
 				prometheus.GaugeValue,
 				1,
 				peerRouterID,
+				peerDescription,
 			))
 		} else {
 			n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
@@ -75,6 +78,7 @@ func (n *RouterNode) GetPeers() {
 				prometheus.GaugeValue,
 				0,
 				peerRouterID,
+				peerDescription,
 			))
 		}
 		// Peer ASN
@@ -83,6 +87,7 @@ func (n *RouterNode) GetPeers() {
 			prometheus.GaugeValue,
 			float64(peerState.GetPeerAs()),
 			peerRouterID,
+			peerDescription,
 		))
 		// Peer Admin State: Up (0), Down (1), PFX_CT (2)
 		n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
@@ -90,6 +95,7 @@ func (n *RouterNode) GetPeers() {
 			prometheus.GaugeValue,
 			float64(peerState.GetAdminState()),
 			peerRouterID,
+			peerDescription,
 		))
 		// Peer Session State: idle (0), connect (1), active (2), opensent (3)
 		// openconfirm (4), established (5).
@@ -98,6 +104,7 @@ func (n *RouterNode) GetPeers() {
 			prometheus.GaugeValue,
 			float64(peerState.GetSessionState()),
 			peerRouterID,
+			peerDescription,
 		))
 		// Local AS advertised to the peer
 		n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
@@ -105,6 +112,7 @@ func (n *RouterNode) GetPeers() {
 			prometheus.GaugeValue,
 			float64(peerState.GetLocalAs()),
 			peerRouterID,
+			peerDescription,
 		))
 
 		peerMessages := peerState.GetMessages()
@@ -136,48 +144,56 @@ func (n *RouterNode) GetPeers() {
 				prometheus.GaugeValue,
 				float64(peerReceivedTotalMessagesCount),
 				peerRouterID,
+				peerDescription,
 			))
 			n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
 				bgpPeerReceivedNotificationMessagesCount,
 				prometheus.GaugeValue,
 				float64(peerReceivedNotificationMessagesCount),
 				peerRouterID,
+				peerDescription,
 			))
 			n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
 				bgpPeerReceivedUpdateMessagesCount,
 				prometheus.GaugeValue,
 				float64(peerReceivedUpdateMessagesCount),
 				peerRouterID,
+				peerDescription,
 			))
 			n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
 				bgpPeerReceivedOpenMessagesCount,
 				prometheus.GaugeValue,
 				float64(peerReceivedOpenMessagesCount),
 				peerRouterID,
+				peerDescription,
 			))
 			n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
 				bgpPeerReceivedKeepaliveMessagesCount,
 				prometheus.GaugeValue,
 				float64(peerReceivedKeepaliveMessagesCount),
 				peerRouterID,
+				peerDescription,
 			))
 			n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
 				bgpPeerReceivedRefreshMessagesCount,
 				prometheus.GaugeValue,
 				float64(peerReceivedRefreshMessagesCount),
 				peerRouterID,
+				peerDescription,
 			))
 			n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
 				bgpPeerReceivedWithdrawUpdateMessagesCount,
 				prometheus.GaugeValue,
 				float64(peerReceivedWithdrawUpdateMessagesCount),
 				peerRouterID,
+				peerDescription,
 			))
 			n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
 				bgpPeerReceivedWithdrawPrefixMessagesCount,
 				prometheus.GaugeValue,
 				float64(peerReceivedWithdrawPrefixMessagesCount),
 				peerRouterID,
+				peerDescription,
 			))
 
 			// The number of messages sent to the peer
@@ -207,48 +223,56 @@ func (n *RouterNode) GetPeers() {
 				prometheus.GaugeValue,
 				float64(peerSentTotalMessagesCount),
 				peerRouterID,
+				peerDescription,
 			))
 			n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
 				bgpPeerSentNotificationMessagesCount,
 				prometheus.GaugeValue,
 				float64(peerSentNotificationMessagesCount),
 				peerRouterID,
+				peerDescription,
 			))
 			n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
 				bgpPeerSentUpdateMessagesCount,
 				prometheus.GaugeValue,
 				float64(peerSentUpdateMessagesCount),
 				peerRouterID,
+				peerDescription,
 			))
 			n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
 				bgpPeerSentOpenMessagesCount,
 				prometheus.GaugeValue,
 				float64(peerSentOpenMessagesCount),
 				peerRouterID,
+				peerDescription,
 			))
 			n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
 				bgpPeerSentKeepaliveMessagesCount,
 				prometheus.GaugeValue,
 				float64(peerSentKeepaliveMessagesCount),
 				peerRouterID,
+				peerDescription,
 			))
 			n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
 				bgpPeerSentRefreshMessagesCount,
 				prometheus.GaugeValue,
 				float64(peerSentRefreshMessagesCount),
 				peerRouterID,
+				peerDescription,
 			))
 			n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
 				bgpPeerSentWithdrawUpdateMessagesCount,
 				prometheus.GaugeValue,
 				float64(peerSentWithdrawUpdateMessagesCount),
 				peerRouterID,
+				peerDescription,
 			))
 			n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
 				bgpPeerSentWithdrawPrefixMessagesCount,
 				prometheus.GaugeValue,
 				float64(peerSentWithdrawPrefixMessagesCount),
 				peerRouterID,
+				peerDescription,
 			))
 
 		}
@@ -259,6 +283,7 @@ func (n *RouterNode) GetPeers() {
 			prometheus.GaugeValue,
 			float64(peerState.GetOutQ()),
 			peerRouterID,
+			peerDescription,
 		))
 		// The number of neighbor flops
 		n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
@@ -266,6 +291,7 @@ func (n *RouterNode) GetPeers() {
 			prometheus.GaugeValue,
 			float64(peerState.GetFlops()),
 			peerRouterID,
+			peerDescription,
 		))
 		// Whether BGP community is being sent
 		n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
@@ -273,6 +299,7 @@ func (n *RouterNode) GetPeers() {
 			prometheus.GaugeValue,
 			float64(peerState.GetSendCommunity()),
 			peerRouterID,
+			peerDescription,
 		))
 		// Whether BGP Private AS is being removed
 		n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
@@ -280,6 +307,7 @@ func (n *RouterNode) GetPeers() {
 			prometheus.GaugeValue,
 			float64(peerState.GetRemovePrivateAs()),
 			peerRouterID,
+			peerDescription,
 		))
 		// Whether authentication password is being set (1) or not (0)
 		passwordSetFlag := 0
@@ -291,6 +319,7 @@ func (n *RouterNode) GetPeers() {
 			prometheus.GaugeValue,
 			float64(passwordSetFlag),
 			peerRouterID,
+			peerDescription,
 		))
 		// Peer Type
 		n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
@@ -298,6 +327,7 @@ func (n *RouterNode) GetPeers() {
 			prometheus.GaugeValue,
 			float64(peerState.GetPeerType()),
 			peerRouterID,
+			peerDescription,
 		))
 
 	}

--- a/pkg/gobgp_exporter/describe_peer.go
+++ b/pkg/gobgp_exporter/describe_peer.go
@@ -22,143 +22,143 @@ var (
 	routerPeer = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "up"),
 		"Is the peer up and in established state (1) or it is not (0).",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	routerPeerAsn = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "asn"),
 		"What is the AS number of the peer",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	routerPeerLocalAsn = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "local_asn"),
 		"What is the AS number presented to the peer by this router.",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	routerPeerAdminState = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "admin_state"),
 		"Is the peer configured for being Up (0), Down (1), or PFX_CT (2)",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	routerPeerSessionState = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "session_state"),
 		"What is the state of BGP session to the peer - unknown (0), idle (1), connect (2), active (3), opensent (4), openconfirm (5), established (6)",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 
 	bgpPeerReceivedTotalMessagesCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "received_message_total_count"),
 		"The total number of messages the BGP peer sent to this router (limited to IPv4).",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 
 	bgpPeerReceivedNotificationMessagesCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "received_notification_message_count"),
 		"How many Notification messages did the BGP peer sent to this router (limited to IPv4).",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 
 	bgpPeerReceivedUpdateMessagesCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "received_update_message_count"),
 		"How many Update messages did the BGP peer sent to this router (limited to IPv4).",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	bgpPeerReceivedOpenMessagesCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "received_open_message_count"),
 		"How many Open messages did the BGP peer sent to this router (limited to IPv4).",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	bgpPeerReceivedKeepaliveMessagesCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "received_keepalive_message_count"),
 		"How many messages did the BGP peer sent to this router (limited to IPv4).",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	bgpPeerReceivedRefreshMessagesCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "received_refresh_message_count"),
 		"How many Refresh messages did the BGP peer sent to this router (limited to IPv4).",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	bgpPeerReceivedWithdrawUpdateMessagesCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "received_withdraw_update_message_count"),
 		"How many WithdrawUpdate messages did the BGP peer sent to this router (limited to IPv4).",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	bgpPeerReceivedWithdrawPrefixMessagesCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "received_withdraw_prefix_message_count"),
 		"How many messages did the BGP peer sent to this router (limited to IPv4).",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 
 	bgpPeerSentTotalMessagesCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "sent_message_total_count"),
 		"The total number of messages this router sent to this BGP peer (limited to IPv4).",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 
 	bgpPeerSentNotificationMessagesCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "sent_notification_message_count"),
 		"How many Notification messages did this router sent to this BGP peer (limited to IPv4).",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 
 	bgpPeerSentUpdateMessagesCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "sent_update_message_count"),
 		"How many Update messages did this router sent to this BGP peer (limited to IPv4).",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	bgpPeerSentOpenMessagesCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "sent_open_message_count"),
 		"How many Open messages did this router sent to this BGP peer (limited to IPv4).",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	bgpPeerSentKeepaliveMessagesCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "sent_keepalive_message_count"),
 		"How many messages did this router sent to this BGP peer (limited to IPv4).",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	bgpPeerSentRefreshMessagesCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "sent_refresh_message_count"),
 		"How many Refresh messages did this router sent to this BGP peer (limited to IPv4).",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	bgpPeerSentWithdrawUpdateMessagesCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "sent_withdraw_update_message_count"),
 		"How many WithdrawUpdate messages did this router sent to this BGP peer (limited to IPv4).",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	bgpPeerSentWithdrawPrefixMessagesCount = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "sent_withdraw_prefix_message_count"),
 		"How many messages did this router sent to this BGP peer (limited to IPv4).",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 
 	bgpPeerOutQueue = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "out_queue_count"),
 		"PeerState.OutQ",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	bgpPeerFlops = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "flop_count"),
 		"PeerState.Flops",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	bgpPeerSendCommunityFlag = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "send_community"),
 		"PeerState.SendCommunity",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	bgpPeerRemovePrivateAsFlag = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "remove_private_as"),
 		"PeerState.RemovePrivateAs",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	bgpPeerPasswodSetFlag = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "password_set"),
 		"Whether the GoBGP peer has been configured (1) for authentication or not (0)",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 	bgpPeerType = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "type"),
 		"PeerState.PeerType",
-		[]string{"name"}, nil,
+		[]string{"name", "description"}, nil,
 	)
 )


### PR DESCRIPTION
This PR adds the gobgp configured peer description as a label to peer-specific metrics. This allows for upstream relabeling in prometheus based on structured peer descriptions.