### PR TITLE
Allow ipv6 and dns as address, following go grpc valid format

### DIFF
--- a/pkg/gobgp_exporter/gobgp_exporter_test.go
+++ b/pkg/gobgp_exporter/gobgp_exporter_test.go
@@ -27,6 +27,9 @@ func TestNewExporter(t *testing.T) {
 		{address: "localaddress:50051", ok: false},
 		{address: "http://localaddress:50051", ok: false},
 		{address: "fuuuu://localaddress:50051", ok: false},
+		{address: "dns:///localhost:50051", ok: true},
+		{address: "[::1]:50051", ok: true},
+		{address: "::1:50051", ok: false},
 	}
 	pollTimeout := 2
 	for _, test := range cases {


### PR DESCRIPTION
Trying to fix #17 by allow ipv6 format as well as dns format in the address field

Following grcp go doc : 

> The target name syntax is defined in https://github.com/grpc/grpc/blob/master/doc/naming.md. e.g. to use dns resolver, a "dns:///" prefix should be applied to the target.

Using `net.SplitHostPort` function to magically get host and port from address  (inspired by https://github.com/grpc/grpc-go/blob/master/internal/resolver/dns/dns_resolver.go#L383) 

When this fails we only allow the `dns://` prefix in the validation. Notice that the last / is not mandatory as the syntax is `dns:[//authority/]host[:port]`

Note : This does not implement support of IPV6 for peers or anything in BGP side (see: https://github.com/greenpau/gobgp_exporter/blob/master/pkg/gobgp_exporter/router_node.go#L77 ). That could done in a next step