### PR TITLE
Implement TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,12 @@ Usage: gobgp-exporter [arguments]
         The minimum interval (in seconds) between collections from a GoBGP server. (default 15)
   -gobgp.timeout int
         Timeout on gRPC requests to a GoBGP server. (default 2)
+  -gobgp.tls
+        Whether to enable TLS for gRPC API access.
+  -gobgp.tls-ca string
+        Optional path to PEM file with CA certificates to be trusted for gRPC API access.
+  -gobgp.tls-server-name string
+        Optional hostname to verify API server as.
   -log.level string
         logging severity level (default "info")
   -metrics
@@ -290,6 +296,9 @@ Documentation: https://github.com/greenpau/gobgp_exporter/
 * __`gobgp.address`:__ Address (host and port) of the GoBGP instance we should
     connect to. This could be a local GoBGP server (`127.0.0.0:50051`, for
     instance), or the address of a remote GoBGP server.
+* __`gobgp.tls`:__ Enable TLS for the GoBGP connection. (default: not set)
+* __`gobgp.tls-ca`:__ Optional path to a PEM file containing certificate authorities to verify GoBGP server certificate against. If empty, the host's root CA set is used instead. (default: empty)
+* __`gobgp.tls-server-name`:__ Optional server name to verify GoBGP server certificate against. If empty, verification will be using the hostname or IP used in `gobgp.address`. (default: empty)
 * __`gobgp.timeout`:__ Timeout on gRPC requests to GoBGP.
 * __`gobgp.poll-interval`:__ The minimum interval (in seconds) between collections from GoBGP server. (default: 15 seconds)
 * __`gobgp.peers`:__ The file containing the mapping between `router_id` and the name (e.g. `hostname`) of a remote peer.

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Documentation: https://github.com/greenpau/gobgp_exporter/
 * __`gobgp.address`:__ Address (host and port) of the GoBGP instance we should
     connect to. This could be a local GoBGP server (`127.0.0.0:50051`, for
     instance), or the address of a remote GoBGP server.
-* __`gobgp.tls`:__ Enable TLS for the GoBGP connection. (default: not set)
+* __`gobgp.tls`:__ Enable TLS for the GoBGP connection. (default: false)
 * __`gobgp.tls-ca`:__ Optional path to a PEM file containing certificate authorities to verify GoBGP server certificate against. If empty, the host's root CA set is used instead. (default: empty)
 * __`gobgp.tls-server-name`:__ Optional server name to verify GoBGP server certificate against. If empty, verification will be using the hostname or IP used in `gobgp.address`. (default: empty)
 * __`gobgp.timeout`:__ Timeout on gRPC requests to GoBGP.

--- a/cmd/gobgp_exporter/main.go
+++ b/cmd/gobgp_exporter/main.go
@@ -57,7 +57,7 @@ func main() {
 		opts.TLS = new(tls.Config)
 		if len(serverTLSCAPath) > 0 {
 			// assuming PEM file here
-			pemCerts, err := os.ReadFile(serverTLSCAPath)
+			pemCerts, err := os.ReadFile(filepath.Clean(serverTLSCAPath))
 			if err != nil {
 				log.Errorf("Could not read TLS CA PEM file %q: %s", serverTLSCAPath, err)
 				os.Exit(1)

--- a/cmd/gobgp_exporter/main.go
+++ b/cmd/gobgp_exporter/main.go
@@ -1,18 +1,24 @@
 package main
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"flag"
 	"fmt"
-	exporter "github.com/greenpau/gobgp_exporter/pkg/gobgp_exporter"
-	"github.com/prometheus/common/log"
 	"net/http"
 	"os"
+
+	exporter "github.com/greenpau/gobgp_exporter/pkg/gobgp_exporter"
+	"github.com/prometheus/common/log"
 )
 
 func main() {
 	var listenAddress string
 	var metricsPath string
 	var serverAddress string
+	var serverTLS bool
+	var serverTLSCAPath string
+	var serverTLSServerName string
 	var pollTimeout int
 	var pollInterval int
 	var isShowMetrics bool
@@ -23,6 +29,9 @@ func main() {
 	flag.StringVar(&listenAddress, "web.listen-address", ":9474", "Address to listen on for web interface and telemetry.")
 	flag.StringVar(&metricsPath, "web.telemetry-path", "/metrics", "Path under which to expose metrics.")
 	flag.StringVar(&serverAddress, "gobgp.address", "127.0.0.1:50051", "gRPC API address of GoBGP server.")
+	flag.BoolVar(&serverTLS, "gobgp.tls", false, "Whether to enable TLS for gRPC API access.")
+	flag.StringVar(&serverTLSCAPath, "gobgp.tls-ca", "", "Optional path to PEM file with CA certificates to be trusted for gRPC API access.")
+	flag.StringVar(&serverTLSServerName, "gobgp.tls-server-name", "", "Optional hostname to verify API server as.")
 	flag.IntVar(&pollTimeout, "gobgp.timeout", 2, "Timeout on gRPC requests to a GoBGP server.")
 	flag.IntVar(&pollInterval, "gobgp.poll-interval", 15, "The minimum interval (in seconds) between collections from a GoBGP server.")
 	flag.StringVar(&authToken, "auth.token", "anonymous", "The X-Token for accessing the exporter itself")
@@ -30,7 +39,7 @@ func main() {
 	flag.BoolVar(&isShowVersion, "version", false, "version information")
 	flag.StringVar(&logLevel, "log.level", "info", "logging severity level")
 
-	var usageHelp = func() {
+	usageHelp := func() {
 		fmt.Fprintf(os.Stderr, "\n%s - Prometheus Exporter for GoBGP\n\n", exporter.GetExporterName())
 		fmt.Fprintf(os.Stderr, "Usage: %s [arguments]\n\n", exporter.GetExporterName())
 		flag.PrintDefaults()
@@ -42,6 +51,28 @@ func main() {
 	opts := exporter.Options{
 		Address: serverAddress,
 		Timeout: pollTimeout,
+	}
+
+	if serverTLS {
+		opts.TLS = new(tls.Config)
+		if len(serverTLSCAPath) > 0 {
+			// assuming PEM file here
+			pemCerts, err := os.ReadFile(serverTLSCAPath)
+			if err != nil {
+				log.Errorf("Could not read TLS CA PEM file %q: %s", serverTLSCAPath, err)
+				os.Exit(1)
+			}
+
+			opts.TLS.RootCAs = x509.NewCertPool()
+			ok := opts.TLS.RootCAs.AppendCertsFromPEM(pemCerts)
+			if !ok {
+				log.Errorf("Could not parse any TLS CA certificate from PEM file %q: %s", serverTLSCAPath, err)
+				os.Exit(1)
+			}
+		}
+		if len(serverTLSServerName) > 0 {
+			opts.TLS.ServerName = serverTLSServerName
+		}
 	}
 
 	if err := log.Base().SetLevel(logLevel); err != nil {

--- a/cmd/gobgp_exporter/main.go
+++ b/cmd/gobgp_exporter/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 
 	exporter "github.com/greenpau/gobgp_exporter/pkg/gobgp_exporter"
 	"github.com/prometheus/common/log"

--- a/pkg/gobgp_exporter/gobgp_exporter.go
+++ b/pkg/gobgp_exporter/gobgp_exporter.go
@@ -15,13 +15,15 @@
 package exporter
 
 import (
+	"crypto/tls"
+	"net/http"
+	"sync"
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/version"
-	"net/http"
-	"sync"
-	"time"
 )
 
 const (
@@ -52,6 +54,7 @@ type Exporter struct {
 // Exporter.
 type Options struct {
 	Address string
+	TLS     *tls.Config
 	Timeout int
 }
 
@@ -68,7 +71,7 @@ func NewExporter(opts Options) (*Exporter, error) {
 		Tokens:  make(map[string]bool),
 	}
 
-	n, err := NewRouterNode(opts.Address, opts.Timeout)
+	n, err := NewRouterNode(opts.Address, opts.Timeout, opts.TLS)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
While under normal conditions it is fine for GoBGP to use an unencrypted connection to the local GoBGP gRPC API, the GoBGP daemon may be set up to expose the API with TLS enabled only. In this case, gobgp-exporter is unable to connect.

This PR implements configuration options to enable TLS, optionally with a custom CA certificate to validate the connection against.
