### PR TITLE
TLS client authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,10 @@ Usage: gobgp-exporter [arguments]
         Whether to enable TLS for gRPC API access.
   -gobgp.tls-ca string
         Optional path to PEM file with CA certificates to be trusted for gRPC API access.
+  -gobgp.tls-client-cert string
+        Optional path to PEM file with client certificate to be used for client authentication.
+  -gobgp.tls-client-key string
+        Optional path to PEM file with client key to be used for client authentication.
   -gobgp.tls-server-name string
         Optional hostname to verify API server as.
   -log.level string
@@ -298,6 +302,8 @@ Documentation: https://github.com/greenpau/gobgp_exporter/
     instance), or the address of a remote GoBGP server.
 * __`gobgp.tls`:__ Enable TLS for the GoBGP connection. (default: false)
 * __`gobgp.tls-ca`:__ Optional path to a PEM file containing certificate authorities to verify GoBGP server certificate against. If empty, the host's root CA set is used instead. (default: empty)
+* __`gobgp.tls-client-cert`:__ Optional path to a PEM file containing the client certificate to authenticate with. (default: empty)
+* __`gobgp.tls-client-key`:__ Optional path to a PEM file containing the key for theclient certificate to authenticate with. (default: empty)
 * __`gobgp.tls-server-name`:__ Optional server name to verify GoBGP server certificate against. If empty, verification will be using the hostname or IP used in `gobgp.address`. (default: empty)
 * __`gobgp.timeout`:__ Timeout on gRPC requests to GoBGP.
 * __`gobgp.poll-interval`:__ The minimum interval (in seconds) between collections from GoBGP server. (default: 15 seconds)

--- a/cmd/gobgp_exporter/main.go
+++ b/cmd/gobgp_exporter/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"crypto"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/pem"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -14,6 +17,79 @@ import (
 	"github.com/prometheus/common/promlog"
 )
 
+func loadCertificatePEM(filePath string) (*x509.Certificate, error) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	rest := content
+	var block *pem.Block
+	var cert *x509.Certificate
+	for len(rest) > 0 {
+		block, rest = pem.Decode(content)
+		if block == nil {
+			// no PEM data found, rest will not have been modified
+			break
+		}
+		content = rest
+		switch block.Type {
+		case "CERTIFICATE":
+			cert, err = x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				return nil, err
+			}
+			return cert, err
+		default:
+			// not the PEM block we're looking for
+			continue
+		}
+	}
+	return nil, errors.New("no certificate PEM block found")
+}
+
+func loadKeyPEM(filePath string) (crypto.PrivateKey, error) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	rest := content
+	var block *pem.Block
+	var key crypto.PrivateKey
+	for len(rest) > 0 {
+		block, rest = pem.Decode(content)
+		if block == nil {
+			// no PEM data found, rest will not have been modified
+			break
+		}
+		switch block.Type {
+		case "RSA PRIVATE KEY":
+			key, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+			if err != nil {
+				return nil, err
+			}
+			return key, err
+		case "PRIVATE KEY":
+			key, err = x509.ParsePKCS8PrivateKey(block.Bytes)
+			if err != nil {
+				return nil, err
+			}
+			return key, err
+		case "EC PRIVATE KEY":
+			key, err = x509.ParseECPrivateKey(block.Bytes)
+			if err != nil {
+				return nil, err
+			}
+			return key, err
+		default:
+			// not the PEM block we're looking for
+			continue
+		}
+	}
+	return nil, errors.New("no private key PEM block found")
+}
+
 func main() {
 	var listenAddress string
 	var metricsPath string
@@ -21,6 +97,8 @@ func main() {
 	var serverTLS bool
 	var serverTLSCAPath string
 	var serverTLSServerName string
+	var serverTLSClientCertPath string
+	var serverTLSClientKeyPath string
 	var pollTimeout int
 	var pollInterval int
 	var isShowMetrics bool
@@ -34,6 +112,8 @@ func main() {
 	flag.BoolVar(&serverTLS, "gobgp.tls", false, "Whether to enable TLS for gRPC API access.")
 	flag.StringVar(&serverTLSCAPath, "gobgp.tls-ca", "", "Optional path to PEM file with CA certificates to be trusted for gRPC API access.")
 	flag.StringVar(&serverTLSServerName, "gobgp.tls-server-name", "", "Optional hostname to verify API server as.")
+	flag.StringVar(&serverTLSClientCertPath, "gobgp.tls-client-cert", "", "Optional path to PEM file with client certificate to be used for client authentication.")
+	flag.StringVar(&serverTLSClientKeyPath, "gobgp.tls-client-key", "", "Optional path to PEM file with client key to be used for client authentication.")
 	flag.IntVar(&pollTimeout, "gobgp.timeout", 2, "Timeout on gRPC requests to a GoBGP server.")
 	flag.IntVar(&pollInterval, "gobgp.poll-interval", 15, "The minimum interval (in seconds) between collections from a GoBGP server.")
 	flag.StringVar(&authToken, "auth.token", "anonymous", "The X-Token for accessing the exporter itself")
@@ -87,6 +167,23 @@ func main() {
 		}
 		if len(serverTLSServerName) > 0 {
 			opts.TLS.ServerName = serverTLSServerName
+		}
+		if len(serverTLSClientCertPath) > 0 && len(serverTLSClientKeyPath) > 0 {
+			// again assuming PEM file
+			cert, err := loadCertificatePEM(serverTLSClientCertPath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to load client certificate: %s", err)
+			}
+			key, err := loadKeyPEM(serverTLSClientKeyPath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to load client key: %s", err)
+			}
+			opts.TLS.Certificates = []tls.Certificate{
+				{
+					Certificate: [][]byte{cert.Raw},
+					PrivateKey:  key,
+				},
+			}
 		}
 	}
 

--- a/cmd/gobgp_exporter/main.go
+++ b/cmd/gobgp_exporter/main.go
@@ -184,6 +184,9 @@ func main() {
 					PrivateKey:  key,
 				},
 			}
+		} else if len(serverTLSClientCertPath) > 0 || len(serverTLSClientKeyPath) > 0 {
+			fmt.Fprintln(os.Stderr, "Only one of client certificate and key was set, must set both.")
+			os.Exit(1)
 		}
 	}
 

--- a/cmd/gobgp_exporter/main.go
+++ b/cmd/gobgp_exporter/main.go
@@ -137,7 +137,7 @@ func main() {
 
 	allowedLogLevel := &promlog.AllowedLevel{}
 	if err := allowedLogLevel.Set(logLevel); err != nil {
-		fmt.Fprintf(os.Stderr, "%s", err.Error())
+		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
 		os.Exit(1)
 	}
 
@@ -154,14 +154,14 @@ func main() {
 			// assuming PEM file here
 			pemCerts, err := os.ReadFile(filepath.Clean(serverTLSCAPath))
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Could not read TLS CA PEM file %q: %s", serverTLSCAPath, err)
+				fmt.Fprintf(os.Stderr, "Could not read TLS CA PEM file %q: %s\n", serverTLSCAPath, err)
 				os.Exit(1)
 			}
 
 			opts.TLS.RootCAs = x509.NewCertPool()
 			ok := opts.TLS.RootCAs.AppendCertsFromPEM(pemCerts)
 			if !ok {
-				fmt.Fprintf(os.Stderr, "Could not parse any TLS CA certificate from PEM file %q: %s", serverTLSCAPath, err)
+				fmt.Fprintf(os.Stderr, "Could not parse any TLS CA certificate from PEM file %q: %s\n", serverTLSCAPath, err)
 				os.Exit(1)
 			}
 		}
@@ -172,11 +172,11 @@ func main() {
 			// again assuming PEM file
 			cert, err := loadCertificatePEM(serverTLSClientCertPath)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to load client certificate: %s", err)
+				fmt.Fprintf(os.Stderr, "Failed to load client certificate: %s\n", err)
 			}
 			key, err := loadKeyPEM(serverTLSClientKeyPath)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to load client key: %s", err)
+				fmt.Fprintf(os.Stderr, "Failed to load client key: %s\n", err)
 			}
 			opts.TLS.Certificates = []tls.Certificate{
 				{


### PR DESCRIPTION
Immediate follow-up to #26 in preparation for https://github.com/osrg/gobgp/pull/2633 which has already been merged and is expected to be included in the next release.

This implements optional usage of a client certificate/key as part of TLS authentication.
