### PR TITLE
Add gobgp_peer_uptime metric

### DIFF
--- a/pkg/gobgp_exporter/collect_peers.go
+++ b/pkg/gobgp_exporter/collect_peers.go
@@ -70,6 +70,7 @@ func (n *RouterNode) GetPeers() {
 	for _, p := range peers {
 		peerState := p.GetState()
 		peerRouterID := peerState.GetNeighborAddress()
+		peerTimers := p.GetTimers()
 
 		// Peer Up/Down
 		if peerState.GetRouterId() != "" {
@@ -87,6 +88,13 @@ func (n *RouterNode) GetPeers() {
 				peerRouterID,
 			))
 		}
+		// Peer uptime
+		n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
+			routerPeerUptime,
+			prometheus.GaugeValue,
+			float64(peerTimers.GetState().GetUptime().GetSeconds()),
+			peerRouterID,
+		))
 		// Peer ASN
 		n.metrics = append(n.metrics, prometheus.MustNewConstMetric(
 			routerPeerAsn,

--- a/pkg/gobgp_exporter/describe.go
+++ b/pkg/gobgp_exporter/describe.go
@@ -32,6 +32,7 @@ func (n *RouterNode) Describe(ch chan<- *prometheus.Desc) {
 	ch <- routerRibAcceptedPathCount
 	ch <- routerPeers
 	ch <- routerPeer
+	ch <- routerPeerUptime
 	ch <- routerPeerAsn
 	ch <- routerPeerLocalAsn
 	ch <- routerPeerAdminState

--- a/pkg/gobgp_exporter/describe_peer.go
+++ b/pkg/gobgp_exporter/describe_peer.go
@@ -24,6 +24,11 @@ var (
 		"Is the peer up and in established state (1) or it is not (0).",
 		[]string{"name"}, nil,
 	)
+	routerPeerUptime = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "peer", "uptime_seconds"),
+		"For how long the peer has been in its current state.",
+		[]string{"name"}, nil,
+	)
 	routerPeerAsn = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "peer", "asn"),
 		"What is the AS number of the peer",


### PR DESCRIPTION
This new metric is basically a counter that will reset whenever a peer changes states. Monitoring the uptime allows to check for session flaps and resets that may be too quick to be noticed using the gobgp_peer_up metric, if all happen between two scrapes.